### PR TITLE
geom_alt props

### DIFF
--- a/data/112/576/908/9/1125769089.geojson
+++ b/data/112/576/908/9/1125769089.geojson
@@ -302,6 +302,9 @@
     },
     "wof:country":"IM",
     "wof:created":1497289999,
+    "wof:geom_alt":[
+        "qs_pg"
+    ],
     "wof:geomhash":"ffafeaecdea8fbbc5f87d3b052753811",
     "wof:hierarchy":[
         {
@@ -312,7 +315,7 @@
         }
     ],
     "wof:id":1125769089,
-    "wof:lastmodified":1566680720,
+    "wof:lastmodified":1582358651,
     "wof:name":"Douglas",
     "wof:parent_id":85681241,
     "wof:placetype":"locality",

--- a/data/856/324/61/85632461.geojson
+++ b/data/856/324/61/85632461.geojson
@@ -712,6 +712,7 @@
     "qs:source":"US State Department, with Natural Earth mods",
     "src:geom":"quattroshapes",
     "src:geom_alt":[
+        "naturalearth",
         "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -759,6 +760,10 @@
     },
     "wof:country":"IM",
     "wof:country_alpha3":"IMN",
+    "wof:geom_alt":[
+        "naturalearth-display-terrestrial-zoom6",
+        "naturalearth"
+    ],
     "wof:geomhash":"a717787bbd15a0e8c5d6d60a273f303a",
     "wof:hierarchy":[
         {
@@ -776,7 +781,7 @@
         "eng",
         "glv"
     ],
-    "wof:lastmodified":1566680710,
+    "wof:lastmodified":1582358651,
     "wof:name":"Isle of Man",
     "wof:parent_id":102191581,
     "wof:placetype":"country",

--- a/data/856/324/61/85632461.geojson
+++ b/data/856/324/61/85632461.geojson
@@ -712,7 +712,6 @@
     "qs:source":"US State Department, with Natural Earth mods",
     "src:geom":"quattroshapes",
     "src:geom_alt":[
-        "naturalearth",
         "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -781,7 +780,7 @@
         "eng",
         "glv"
     ],
-    "wof:lastmodified":1582358651,
+    "wof:lastmodified":1583239949,
     "wof:name":"Isle of Man",
     "wof:parent_id":102191581,
     "wof:placetype":"country",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.