### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/112/576/908/9/1125769089.geojson
+++ b/data/112/576/908/9/1125769089.geojson
@@ -28,6 +28,9 @@
     "name:ara_x_preferred":[
         "\u062f\u0648\u063a\u0644\u0627\u0633"
     ],
+    "name:arz_x_preferred":[
+        "\u062f\u0648\u062c\u0644\u0627\u0633"
+    ],
     "name:ast_x_preferred":[
         "Douglas"
     ],
@@ -42,6 +45,9 @@
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0414\u0443\u0433\u043b\u0430\u0441"
+    ],
+    "name:bel_x_variant":[
+        "\u0414\u0443\u0433\u043b\u0430\u0441"
     ],
     "name:ben_x_preferred":[
         "\u09a1\u0997\u09b2\u09be\u09b8"
@@ -103,6 +109,9 @@
     "name:fra_x_preferred":[
         "Douglas"
     ],
+    "name:frr_x_preferred":[
+        "Douglas"
+    ],
     "name:fry_x_preferred":[
         "Douglas"
     ],
@@ -139,6 +148,9 @@
     "name:ind_x_preferred":[
         "Douglas"
     ],
+    "name:isl_x_preferred":[
+        "Douglas"
+    ],
     "name:ita_x_preferred":[
         "Douglas"
     ],
@@ -166,6 +178,9 @@
     "name:lrc_x_preferred":[
         "\u062f\u0627\u06af\u0644\u0627\u0633"
     ],
+    "name:ltz_x_preferred":[
+        "Douglas"
+    ],
     "name:mar_x_preferred":[
         "\u0921\u0917\u094d\u0932\u0938"
     ],
@@ -174,6 +189,9 @@
     ],
     "name:mri_x_preferred":[
         "Douglas"
+    ],
+    "name:mzn_x_preferred":[
+        "\u062f\u0648\u06af\u0644\u0627\u0633"
     ],
     "name:nan_x_preferred":[
         "Douglas"
@@ -247,6 +265,9 @@
     "name:tha_x_preferred":[
         "\u0e14\u0e31\u0e01\u0e25\u0e32\u0e2a"
     ],
+    "name:tuk_x_preferred":[
+        "Douglas"
+    ],
     "name:tur_x_preferred":[
         "Douglas"
     ],
@@ -268,8 +289,14 @@
     "name:war_x_preferred":[
         "Douglas"
     ],
+    "name:wuu_x_preferred":[
+        "\u9053\u683c\u62c9\u65af"
+    ],
     "name:xmf_x_preferred":[
         "\u10d3\u10e3\u10d2\u10da\u10d0\u10e1\u10d8"
+    ],
+    "name:yue_x_preferred":[
+        "\u5fb7\u683c\u62c9\u65af"
     ],
     "name:zho_x_preferred":[
         "\u9053\u683c\u62c9\u65af"
@@ -320,7 +347,7 @@
         }
     ],
     "wof:id":1125769089,
-    "wof:lastmodified":1636502854,
+    "wof:lastmodified":1690932076,
     "wof:name":"Douglas",
     "wof:parent_id":85681241,
     "wof:placetype":"locality",

--- a/data/112/577/226/9/1125772269.geojson
+++ b/data/112/577/226/9/1125772269.geojson
@@ -31,6 +31,9 @@
     "name:fra_x_preferred":[
         "Port Soderick"
     ],
+    "name:gle_x_preferred":[
+        "Purt Soderick"
+    ],
     "name:glv_x_preferred":[
         "Purt Soderick"
     ],
@@ -87,7 +90,7 @@
         }
     ],
     "wof:id":1125772269,
-    "wof:lastmodified":1566680721,
+    "wof:lastmodified":1690932076,
     "wof:name":"Port Soderick",
     "wof:parent_id":85681241,
     "wof:placetype":"locality",

--- a/data/112/580/546/7/1125805467.geojson
+++ b/data/112/580/546/7/1125805467.geojson
@@ -31,6 +31,9 @@
     "name:fra_x_preferred":[
         "Colby"
     ],
+    "name:gle_x_preferred":[
+        "Colby"
+    ],
     "name:glv_x_preferred":[
         "Colby"
     ],
@@ -93,7 +96,7 @@
         }
     ],
     "wof:id":1125805467,
-    "wof:lastmodified":1566680716,
+    "wof:lastmodified":1690932072,
     "wof:name":"Colby",
     "wof:parent_id":85681241,
     "wof:placetype":"locality",

--- a/data/112/580/548/1/1125805481.geojson
+++ b/data/112/580/548/1/1125805481.geojson
@@ -73,6 +73,9 @@
     "name:bre_x_preferred":[
         "Kione Droghad"
     ],
+    "name:bul_x_preferred":[
+        "\u041e\u043d\u043a\u044a\u043d"
+    ],
     "name:cat_x_preferred":[
         "Onchan"
     ],
@@ -181,6 +184,9 @@
     "name:gle_x_preferred":[
         "Onchan"
     ],
+    "name:gle_x_variant":[
+        "Kione Droghad"
+    ],
     "name:glg_x_preferred":[
         "Onchan"
     ],
@@ -201,6 +207,9 @@
     ],
     "name:hau_x_preferred":[
         "Onchan"
+    ],
+    "name:heb_x_preferred":[
+        "\u05d0\u05d5\u05e0\u05db\u05d0\u05df"
     ],
     "name:her_x_preferred":[
         "Onchan"
@@ -550,6 +559,9 @@
     "name:tum_x_preferred":[
         "Onchan"
     ],
+    "name:tur_x_preferred":[
+        "Onchan"
+    ],
     "name:twi_x_preferred":[
         "Onchan"
     ],
@@ -657,7 +669,7 @@
         }
     ],
     "wof:id":1125805481,
-    "wof:lastmodified":1566680717,
+    "wof:lastmodified":1690932073,
     "wof:name":"Conchan",
     "wof:parent_id":85681241,
     "wof:placetype":"locality",

--- a/data/112/582/950/5/1125829505.geojson
+++ b/data/112/582/950/5/1125829505.geojson
@@ -37,7 +37,13 @@
     "name:fra_x_preferred":[
         "Port Saint Mary"
     ],
+    "name:frr_x_preferred":[
+        "Port St. Mary"
+    ],
     "name:gla_x_preferred":[
+        "Purt le Moirrey"
+    ],
+    "name:gle_x_preferred":[
         "Purt le Moirrey"
     ],
     "name:glv_x_preferred":[
@@ -66,6 +72,9 @@
     ],
     "name:swe_x_preferred":[
         "Port Saint Mary"
+    ],
+    "name:zho_x_preferred":[
+        "\u8056\u746a\u9e97\u6e2f"
     ],
     "qs_pg:aaroncc":"IM",
     "qs_pg:gn_country":"IM",
@@ -117,7 +126,7 @@
         }
     ],
     "wof:id":1125829505,
-    "wof:lastmodified":1566680719,
+    "wof:lastmodified":1690932075,
     "wof:name":"Port St. Mary",
     "wof:parent_id":85681241,
     "wof:placetype":"locality",

--- a/data/112/582/951/5/1125829515.geojson
+++ b/data/112/582/951/5/1125829515.geojson
@@ -22,6 +22,9 @@
     "mz:is_current":1,
     "mz:min_zoom":12.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:dan_x_preferred":[
+        "Sulby"
+    ],
     "name:eng_x_preferred":[
         "Sulby"
     ],
@@ -29,6 +32,9 @@
         "Sulby"
     ],
     "name:fra_x_preferred":[
+        "Sulby"
+    ],
+    "name:gle_x_preferred":[
         "Sulby"
     ],
     "name:glv_x_preferred":[
@@ -87,7 +93,7 @@
         }
     ],
     "wof:id":1125829515,
-    "wof:lastmodified":1566680719,
+    "wof:lastmodified":1690932075,
     "wof:name":"Sulby",
     "wof:parent_id":85681241,
     "wof:placetype":"locality",

--- a/data/112/583/788/5/1125837885.geojson
+++ b/data/112/583/788/5/1125837885.geojson
@@ -37,6 +37,9 @@
     "name:fra_x_preferred":[
         "Dalby"
     ],
+    "name:gle_x_preferred":[
+        "Delbee"
+    ],
     "name:glv_x_preferred":[
         "Delbee"
     ],
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":1125837885,
-    "wof:lastmodified":1636502855,
+    "wof:lastmodified":1690932076,
     "wof:name":"Dalby",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/112/585/896/3/1125858963.geojson
+++ b/data/112/585/896/3/1125858963.geojson
@@ -34,6 +34,9 @@
     "name:gla_x_preferred":[
         "Forsdal"
     ],
+    "name:gle_x_preferred":[
+        "Forsdal"
+    ],
     "name:glv_x_preferred":[
         "Forsdal"
     ],
@@ -96,7 +99,7 @@
         }
     ],
     "wof:id":1125858963,
-    "wof:lastmodified":1566680720,
+    "wof:lastmodified":1690932076,
     "wof:name":"Foxdale",
     "wof:parent_id":85681241,
     "wof:placetype":"locality",

--- a/data/112/587/356/5/1125873565.geojson
+++ b/data/112/587/356/5/1125873565.geojson
@@ -43,6 +43,9 @@
     "name:fra_x_preferred":[
         "Ballasalla"
     ],
+    "name:gle_x_preferred":[
+        "Balley Sallagh"
+    ],
     "name:glv_x_preferred":[
         "Balley Sallagh"
     ],
@@ -105,7 +108,7 @@
         }
     ],
     "wof:id":1125873565,
-    "wof:lastmodified":1566680717,
+    "wof:lastmodified":1690932073,
     "wof:name":"Ballasalla",
     "wof:parent_id":85681241,
     "wof:placetype":"locality",

--- a/data/112/587/357/5/1125873575.geojson
+++ b/data/112/587/357/5/1125873575.geojson
@@ -133,6 +133,9 @@
     "name:gle_x_preferred":[
         "St John's"
     ],
+    "name:gle_x_variant":[
+        "Balley Keeill Eoin"
+    ],
     "name:glg_x_preferred":[
         "St John's"
     ],
@@ -382,6 +385,9 @@
     "name:zea_x_preferred":[
         "St John's"
     ],
+    "name:zho_x_preferred":[
+        "\u8056\u838a\u65af"
+    ],
     "name:zul_x_preferred":[
         "St John's"
     ],
@@ -435,7 +441,7 @@
         }
     ],
     "wof:id":1125873575,
-    "wof:lastmodified":1566680717,
+    "wof:lastmodified":1690932073,
     "wof:name":"St. Johns",
     "wof:parent_id":85681241,
     "wof:placetype":"locality",

--- a/data/112/588/579/7/1125885797.geojson
+++ b/data/112/588/579/7/1125885797.geojson
@@ -22,8 +22,14 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Castletown"
+    ],
     "name:azb_x_preferred":[
         "\u06a9\u0633\u0644\u200c\u062a\u0627\u0648\u0646"
+    ],
+    "name:bel_x_preferred":[
+        "\u041a\u0430\u0441\u043b\u0442\u0430\u045e\u043d"
     ],
     "name:bre_x_preferred":[
         "Balley Chashtal"
@@ -40,6 +46,9 @@
     "name:deu_x_preferred":[
         "Castletown"
     ],
+    "name:ell_x_preferred":[
+        "\u039a\u03ac\u03c3\u03bb\u03c4\u03b1\u03bf\u03c5\u03bd"
+    ],
     "name:eng_x_preferred":[
         "Castletown"
     ],
@@ -53,6 +62,9 @@
         "Castletown"
     ],
     "name:fra_x_preferred":[
+        "Castletown"
+    ],
+    "name:frr_x_preferred":[
         "Castletown"
     ],
     "name:gla_x_preferred":[
@@ -154,7 +166,7 @@
         }
     ],
     "wof:id":1125885797,
-    "wof:lastmodified":1566680715,
+    "wof:lastmodified":1690932071,
     "wof:name":"Castletown",
     "wof:parent_id":85681241,
     "wof:placetype":"locality",

--- a/data/112/589/878/1/1125898781.geojson
+++ b/data/112/589/878/1/1125898781.geojson
@@ -23,11 +23,17 @@
     "name:ceb_x_preferred":[
         "The Niarbyl"
     ],
+    "name:deu_x_preferred":[
+        "Niarbyl"
+    ],
     "name:eng_x_preferred":[
         "Niarbyl"
     ],
     "name:eus_x_preferred":[
         "Niarbyl"
+    ],
+    "name:gle_x_preferred":[
+        "Yn Arbyl"
     ],
     "name:glv_x_preferred":[
         "Yn Arbyl"
@@ -85,7 +91,7 @@
         }
     ],
     "wof:id":1125898781,
-    "wof:lastmodified":1566680716,
+    "wof:lastmodified":1690932072,
     "wof:name":"Niarbyl",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/112/589/881/3/1125898813.geojson
+++ b/data/112/589/881/3/1125898813.geojson
@@ -29,6 +29,9 @@
     "name:fra_x_preferred":[
         "Glen Vine"
     ],
+    "name:gle_x_preferred":[
+        "Glion Vian"
+    ],
     "name:glv_x_preferred":[
         "Glion Vian"
     ],
@@ -81,7 +84,7 @@
         }
     ],
     "wof:id":1125898813,
-    "wof:lastmodified":1566680715,
+    "wof:lastmodified":1690932071,
     "wof:name":"Glen Vine",
     "wof:parent_id":85681241,
     "wof:placetype":"locality",

--- a/data/112/589/884/5/1125898845.geojson
+++ b/data/112/589/884/5/1125898845.geojson
@@ -29,6 +29,9 @@
     "name:fra_x_preferred":[
         "Barregarrow"
     ],
+    "name:gle_x_preferred":[
+        "Bayr Garroo"
+    ],
     "name:glv_x_preferred":[
         "Bayr Garroo"
     ],
@@ -81,7 +84,7 @@
         }
     ],
     "wof:id":1125898845,
-    "wof:lastmodified":1566680716,
+    "wof:lastmodified":1690932072,
     "wof:name":"Barregarrow",
     "wof:parent_id":85681241,
     "wof:placetype":"locality",

--- a/data/112/591/075/7/1125910757.geojson
+++ b/data/112/591/075/7/1125910757.geojson
@@ -34,6 +34,9 @@
     "name:fra_x_preferred":[
         "Union Mills"
     ],
+    "name:gle_x_preferred":[
+        "Mwyllin Doo Aah"
+    ],
     "name:glv_x_preferred":[
         "Mwyllin Doo Aah"
     ],
@@ -45,6 +48,9 @@
     ],
     "name:slk_x_preferred":[
         "Union Mills"
+    ],
+    "name:zho_x_preferred":[
+        "\u806f\u5408\u7c73\u723e\u65af"
     ],
     "qs_pg:aaroncc":"IM",
     "qs_pg:gn_country":"IM",
@@ -96,7 +102,7 @@
         }
     ],
     "wof:id":1125910757,
-    "wof:lastmodified":1566680718,
+    "wof:lastmodified":1690932074,
     "wof:name":"Union Mills",
     "wof:parent_id":85681241,
     "wof:placetype":"locality",

--- a/data/112/593/572/7/1125935727.geojson
+++ b/data/112/593/572/7/1125935727.geojson
@@ -29,6 +29,9 @@
     "name:fra_x_preferred":[
         "Braaid"
     ],
+    "name:gle_x_preferred":[
+        "Yn Braaid"
+    ],
     "name:glv_x_preferred":[
         "Yn Braaid"
     ],
@@ -37,6 +40,9 @@
     ],
     "name:por_x_preferred":[
         "Braaid"
+    ],
+    "name:zho_x_preferred":[
+        "\u7562\u62c9\u5fb7"
     ],
     "qs_pg:aaroncc":"IM",
     "qs_pg:gn_country":null,
@@ -84,7 +90,7 @@
         }
     ],
     "wof:id":1125935727,
-    "wof:lastmodified":1566680712,
+    "wof:lastmodified":1690932070,
     "wof:name":"Braaid",
     "wof:parent_id":85681241,
     "wof:placetype":"locality",

--- a/data/112/595/251/9/1125952519.geojson
+++ b/data/112/595/251/9/1125952519.geojson
@@ -31,7 +31,13 @@
     "name:fra_x_preferred":[
         "Cregneash"
     ],
+    "name:frr_x_preferred":[
+        "Cregneash"
+    ],
     "name:gla_x_preferred":[
+        "Creneash"
+    ],
+    "name:gle_x_preferred":[
         "Creneash"
     ],
     "name:glv_x_preferred":[
@@ -51,6 +57,9 @@
     ],
     "name:ukr_x_preferred":[
         "\u041a\u0440\u0435\u0433\u043d\u0435\u0448"
+    ],
+    "name:zho_x_preferred":[
+        "\u514b\u96f7\u5c3c\u4e9e\u751a"
     ],
     "qs_pg:aaroncc":"IM",
     "qs_pg:gn_country":"IM",
@@ -102,7 +111,7 @@
         }
     ],
     "wof:id":1125952519,
-    "wof:lastmodified":1566680713,
+    "wof:lastmodified":1690932070,
     "wof:name":"Cregneish",
     "wof:parent_id":85681241,
     "wof:placetype":"locality",

--- a/data/112/595/254/5/1125952545.geojson
+++ b/data/112/595/254/5/1125952545.geojson
@@ -22,6 +22,12 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Laxey"
+    ],
+    "name:cat_x_preferred":[
+        "Laxey"
+    ],
     "name:ceb_x_preferred":[
         "Laxey"
     ],
@@ -35,6 +41,9 @@
         "Laxey"
     ],
     "name:fra_x_preferred":[
+        "Laxey"
+    ],
+    "name:frr_x_preferred":[
         "Laxey"
     ],
     "name:gla_x_preferred":[
@@ -136,7 +145,7 @@
         }
     ],
     "wof:id":1125952545,
-    "wof:lastmodified":1566680713,
+    "wof:lastmodified":1690932071,
     "wof:name":"Laxey",
     "wof:parent_id":85681241,
     "wof:placetype":"locality",

--- a/data/112/595/256/1/1125952561.geojson
+++ b/data/112/595/256/1/1125952561.geojson
@@ -22,13 +22,25 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Peel"
+    ],
     "name:azb_x_preferred":[
         "\u067e\u06cc\u0644"
+    ],
+    "name:bel_x_preferred":[
+        "\u041f\u0456\u043b"
     ],
     "name:bre_x_preferred":[
         "Purt ny h-Inshey"
     ],
+    "name:bul_x_preferred":[
+        "\u041f\u0438\u0439\u043b"
+    ],
     "name:ceb_x_preferred":[
+        "Peel"
+    ],
+    "name:ces_x_preferred":[
         "Peel"
     ],
     "name:cym_x_preferred":[
@@ -50,6 +62,9 @@
         "\u067e\u06cc\u0644"
     ],
     "name:fra_x_preferred":[
+        "Peel"
+    ],
+    "name:frr_x_preferred":[
         "Peel"
     ],
     "name:gla_x_preferred":[
@@ -145,7 +160,7 @@
         }
     ],
     "wof:id":1125952561,
-    "wof:lastmodified":1566680713,
+    "wof:lastmodified":1690932071,
     "wof:name":"Peel",
     "wof:parent_id":85681241,
     "wof:placetype":"locality",

--- a/data/112/597/318/9/1125973189.geojson
+++ b/data/112/597/318/9/1125973189.geojson
@@ -29,6 +29,9 @@
     "name:ara_x_variant":[
         "\u062f\u0648\u063a\u0644\u0627\u0633"
     ],
+    "name:arz_x_preferred":[
+        "\u062f\u0648\u062c\u0644\u0627\u0633"
+    ],
     "name:ast_x_preferred":[
         "Douglas"
     ],
@@ -43,6 +46,9 @@
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0414\u0443\u0433\u043b\u0430\u0441"
+    ],
+    "name:bel_x_variant":[
+        "\u0414\u0443\u0433\u043b\u0430\u0441"
     ],
     "name:ben_x_preferred":[
         "\u09a1\u0997\u09b2\u09be\u09b8"
@@ -101,6 +107,9 @@
     "name:fra_x_preferred":[
         "Douglas"
     ],
+    "name:frr_x_preferred":[
+        "Douglas"
+    ],
     "name:fry_x_preferred":[
         "Douglas"
     ],
@@ -134,6 +143,9 @@
     "name:ind_x_preferred":[
         "Douglas"
     ],
+    "name:isl_x_preferred":[
+        "Douglas"
+    ],
     "name:ita_x_preferred":[
         "Douglas"
     ],
@@ -161,6 +173,9 @@
     "name:lrc_x_preferred":[
         "\u062f\u0627\u06af\u0644\u0627\u0633"
     ],
+    "name:ltz_x_preferred":[
+        "Douglas"
+    ],
     "name:mar_x_preferred":[
         "\u0921\u0917\u094d\u0932\u0938"
     ],
@@ -169,6 +184,9 @@
     ],
     "name:mri_x_preferred":[
         "Douglas"
+    ],
+    "name:mzn_x_preferred":[
+        "\u062f\u0648\u06af\u0644\u0627\u0633"
     ],
     "name:nan_x_preferred":[
         "Douglas"
@@ -239,6 +257,9 @@
     "name:tha_x_preferred":[
         "\u0e14\u0e31\u0e01\u0e25\u0e32\u0e2a"
     ],
+    "name:tuk_x_preferred":[
+        "Douglas"
+    ],
     "name:tur_x_preferred":[
         "Douglas"
     ],
@@ -257,8 +278,14 @@
     "name:war_x_preferred":[
         "Douglas"
     ],
+    "name:wuu_x_preferred":[
+        "\u9053\u683c\u62c9\u65af"
+    ],
     "name:xmf_x_preferred":[
         "\u10d3\u10e3\u10d2\u10da\u10d0\u10e1\u10d8"
+    ],
+    "name:yue_x_preferred":[
+        "\u5fb7\u683c\u62c9\u65af"
     ],
     "name:zho_x_preferred":[
         "\u9053\u683c\u62c9\u65af"
@@ -309,7 +336,7 @@
         }
     ],
     "wof:id":1125973189,
-    "wof:lastmodified":1636502854,
+    "wof:lastmodified":1690932074,
     "wof:name":"Douglas",
     "wof:parent_id":85681241,
     "wof:placetype":"locality",

--- a/data/112/597/354/1/1125973541.geojson
+++ b/data/112/597/354/1/1125973541.geojson
@@ -37,6 +37,9 @@
     "name:fra_x_preferred":[
         "Port Erin"
     ],
+    "name:frr_x_preferred":[
+        "Port Erin"
+    ],
     "name:gla_x_preferred":[
         "Purt \u00c7hiarn"
     ],
@@ -78,6 +81,9 @@
     ],
     "name:swe_x_preferred":[
         "Port Erin"
+    ],
+    "name:zho_x_preferred":[
+        "\u827e\u7433\u6e2f"
     ],
     "qs_pg:aaroncc":"IM",
     "qs_pg:gn_country":"IM",
@@ -130,7 +136,7 @@
         }
     ],
     "wof:id":1125973541,
-    "wof:lastmodified":1566680718,
+    "wof:lastmodified":1690932074,
     "wof:name":"Port Erin",
     "wof:parent_id":85681241,
     "wof:placetype":"locality",

--- a/data/112/598/953/5/1125989535.geojson
+++ b/data/112/598/953/5/1125989535.geojson
@@ -22,13 +22,22 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Ramsey"
+    ],
     "name:azb_x_preferred":[
         "\u0631\u0645\u0632\u06cc"
+    ],
+    "name:bel_x_preferred":[
+        "\u0420\u0430\u043c\u0441\u0456"
     ],
     "name:bre_x_preferred":[
         "Rhumsaa"
     ],
     "name:ceb_x_preferred":[
+        "Ramsey"
+    ],
+    "name:cym_x_preferred":[
         "Ramsey"
     ],
     "name:deu_x_preferred":[
@@ -50,6 +59,9 @@
         "Ramsey"
     ],
     "name:fra_x_preferred":[
+        "Ramsey"
+    ],
+    "name:frr_x_preferred":[
         "Ramsey"
     ],
     "name:gla_x_preferred":[
@@ -93,6 +105,9 @@
     ],
     "name:swe_x_preferred":[
         "Ramsey"
+    ],
+    "name:urd_x_preferred":[
+        "\u0631\u0645\u0633\u06cc"
     ],
     "name:zho_x_preferred":[
         "\u62c9\u59c6\u9f4a"
@@ -148,7 +163,7 @@
         }
     ],
     "wof:id":1125989535,
-    "wof:lastmodified":1566680719,
+    "wof:lastmodified":1690932075,
     "wof:name":"Ramsey",
     "wof:parent_id":85681241,
     "wof:placetype":"locality",

--- a/data/112/599/487/3/1125994873.geojson
+++ b/data/112/599/487/3/1125994873.geojson
@@ -71,6 +71,9 @@
     "name:bre_x_preferred":[
         "Kione Droghad"
     ],
+    "name:bul_x_preferred":[
+        "\u041e\u043d\u043a\u044a\u043d"
+    ],
     "name:cat_x_preferred":[
         "Onchan"
     ],
@@ -179,6 +182,9 @@
     "name:gle_x_preferred":[
         "Onchan"
     ],
+    "name:gle_x_variant":[
+        "Kione Droghad"
+    ],
     "name:glg_x_preferred":[
         "Onchan"
     ],
@@ -199,6 +205,9 @@
     ],
     "name:hau_x_preferred":[
         "Onchan"
+    ],
+    "name:heb_x_preferred":[
+        "\u05d0\u05d5\u05e0\u05db\u05d0\u05df"
     ],
     "name:her_x_preferred":[
         "Onchan"
@@ -548,6 +557,9 @@
     "name:tum_x_preferred":[
         "Onchan"
     ],
+    "name:tur_x_preferred":[
+        "Onchan"
+    ],
     "name:twi_x_preferred":[
         "Onchan"
     ],
@@ -651,7 +663,7 @@
         }
     ],
     "wof:id":1125994873,
-    "wof:lastmodified":1566680717,
+    "wof:lastmodified":1690932074,
     "wof:name":"Onchan",
     "wof:parent_id":85681241,
     "wof:placetype":"locality",

--- a/data/112/601/042/7/1126010427.geojson
+++ b/data/112/601/042/7/1126010427.geojson
@@ -22,6 +22,12 @@
     "mz:is_current":1,
     "mz:min_zoom":12.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:bar_x_preferred":[
+        "Andreas"
+    ],
+    "name:deu_x_preferred":[
+        "Andreas"
+    ],
     "name:eng_x_preferred":[
         "Andreas"
     ],
@@ -29,6 +35,9 @@
         "Andreas"
     ],
     "name:fra_x_preferred":[
+        "Andreas"
+    ],
+    "name:gle_x_preferred":[
         "Andreas"
     ],
     "name:glv_x_preferred":[
@@ -96,7 +105,7 @@
         }
     ],
     "wof:id":1126010427,
-    "wof:lastmodified":1566680719,
+    "wof:lastmodified":1690932075,
     "wof:name":"Andreas",
     "wof:parent_id":85681241,
     "wof:placetype":"locality",

--- a/data/112/601/965/1/1126019651.geojson
+++ b/data/112/601/965/1/1126019651.geojson
@@ -29,6 +29,9 @@
     "name:fra_x_preferred":[
         "Strang"
     ],
+    "name:glv_x_preferred":[
+        "Yn Strang"
+    ],
     "name:nld_x_preferred":[
         "Strang"
     ],
@@ -78,7 +81,7 @@
         }
     ],
     "wof:id":1126019651,
-    "wof:lastmodified":1566680719,
+    "wof:lastmodified":1690932075,
     "wof:name":"Strang",
     "wof:parent_id":85681241,
     "wof:placetype":"locality",

--- a/data/856/324/61/85632461.geojson
+++ b/data/856/324/61/85632461.geojson
@@ -43,6 +43,9 @@
     "name:ang_x_preferred":[
         "Man\u012beg"
     ],
+    "name:anp_x_preferred":[
+        "\u0906\u0907\u0932 \u0911\u092b \u092e\u0948\u0928"
+    ],
     "name:ara_x_preferred":[
         "\u062c\u0632\u064a\u0631\u0629 \u0645\u0627\u0646"
     ],
@@ -242,11 +245,17 @@
     "name:glv_x_preferred":[
         "Mannin"
     ],
+    "name:gsw_x_preferred":[
+        "Isle of Man"
+    ],
     "name:guj_x_preferred":[
         "\u0a87\u0ab8\u0acd\u0ab2\u0ac7 \u0a93\u0aab \u0aae\u0ac5\u0aa8"
     ],
     "name:guj_x_variant":[
         "\u0a87\u0ab8\u0acd\u0ab2\u0ac7 \u0a93\u0aab \u0aae\u0ac7\u0aa8"
+    ],
+    "name:hak_x_preferred":[
+        "Man T\u00f3"
     ],
     "name:hau_x_preferred":[
         "Isle of Man"
@@ -314,6 +323,9 @@
     "name:jpn_x_preferred":[
         "\u30de\u30f3\u5cf6"
     ],
+    "name:kaa_x_preferred":[
+        "Men ataw\u0131"
+    ],
     "name:kan_x_preferred":[
         "\u0c90\u0cb2\u0ccd \u0c86\u0cab\u0ccd \u0cae\u0ccd\u0caf\u0cbe\u0ca8\u0ccd"
     ],
@@ -340,6 +352,9 @@
     "name:kor_x_preferred":[
         "\ub9e8\uc12c",
         "\ub9e8 \uc12c"
+    ],
+    "name:ksh_x_preferred":[
+        "Isle of Man"
     ],
     "name:lat_x_preferred":[
         "Monapia"
@@ -379,6 +394,9 @@
     "name:lrc_x_preferred":[
         "\u0645\u06cc\u0646\u0627\u06a4\u06d5 \u0645\u0623\u0646"
     ],
+    "name:ltz_x_preferred":[
+        "Insel Man"
+    ],
     "name:lzh_x_preferred":[
         "\u66fc\u5cf6"
     ],
@@ -393,6 +411,9 @@
     ],
     "name:mar_x_variant":[
         "\u0907\u0938\u094d\u0932\u0947 \u0911\u092b \u092e\u0945\u0928"
+    ],
+    "name:mdf_x_preferred":[
+        "\u041c\u044d\u043d \u0446\u0451\u043d\u0433\u0430"
     ],
     "name:mkd_x_preferred":[
         "\u041c\u0430\u043d (\u043e\u0441\u0442\u0440\u043e\u0432)",
@@ -457,6 +478,9 @@
     "name:oci_x_preferred":[
         "Illa de Man"
     ],
+    "name:olo_x_preferred":[
+        "Manninsuari"
+    ],
     "name:ori_x_preferred":[
         "\u0b06\u0b07\u0b32\u0b4d \u0b05\u0b2b\u0b4d \u0b2e\u0b48\u0b28\u0b4d"
     ],
@@ -494,6 +518,9 @@
     "name:ron_x_variant":[
         "Insulele Man"
     ],
+    "name:rue_x_preferred":[
+        "\u041e\u0441\u0442\u0440\u043e\u0432 \u041c\u0435\u043d"
+    ],
     "name:rus_x_preferred":[
         "\u041e\u0441\u0442\u0440\u043e\u0432 \u041c\u044d\u043d"
     ],
@@ -509,6 +536,9 @@
     ],
     "name:sco_x_variant":[
         "Isle o Mann"
+    ],
+    "name:shn_x_preferred":[
+        "\u1075\u102f\u107c\u103a\u1019\u1085\u107c\u103a\u1038"
     ],
     "name:sin_x_preferred":[
         "\u0db8\u0db1\u0dd4\u0dc2\u0dca\u200d\u0dba \u0daf\u0dd6\u0db4\u0dad"
@@ -586,6 +616,9 @@
     "name:ton_x_preferred":[
         "Motu Mani"
     ],
+    "name:tuk_x_preferred":[
+        "Man Adasy"
+    ],
     "name:tur_x_preferred":[
         "Man Adas\u0131"
     ],
@@ -599,11 +632,17 @@
     "name:urd_x_preferred":[
         "\u0622\u0626\u0644 \u0622\u0641 \u0645\u06cc\u0646"
     ],
+    "name:uzb_x_preferred":[
+        "Men oroli"
+    ],
     "name:vec_x_preferred":[
         "\u00ccxo\u0142a de Man"
     ],
     "name:vie_x_preferred":[
         "\u0110\u1ea3o Man"
+    ],
+    "name:vls_x_preferred":[
+        "Eyland Man"
     ],
     "name:war_x_preferred":[
         "Isla han Man"
@@ -613,6 +652,9 @@
     ],
     "name:xal_x_preferred":[
         "\u041c\u044d\u043d\u0438\u043d \u0410\u0440\u043b"
+    ],
+    "name:xmf_x_preferred":[
+        "\u10d9\u10dd\u10d9\u10d8 \u10db\u10d4\u10dc\u10d8"
     ],
     "name:yor_x_preferred":[
         "Er\u00e9k\u00f9\u1e63\u00f9 il\u1eb9\u0300 Man"
@@ -856,7 +898,7 @@
         "eng",
         "glv"
     ],
-    "wof:lastmodified":1636502854,
+    "wof:lastmodified":1690932070,
     "wof:name":"Isle of Man",
     "wof:parent_id":102191581,
     "wof:placetype":"country",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.