### PR TITLE
im concordances, placetype local, and more

### DIFF
--- a/data/856/324/61/85632461.geojson
+++ b/data/856/324/61/85632461.geojson
@@ -866,6 +866,7 @@
         "gn:id":3042225,
         "gp:id":23424847,
         "hasc:id":"IM",
+        "iso:code":"IM",
         "m49:code":"833",
         "marc:id":"uik",
         "mzb:id":"isle-of-man",
@@ -876,6 +877,7 @@
         "uncrt:id":"GBM",
         "wd:id":"Q9676"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         85681241
     ],
@@ -902,7 +904,7 @@
         "eng",
         "glv"
     ],
-    "wof:lastmodified":1694639669,
+    "wof:lastmodified":1695881329,
     "wof:name":"Isle of Man",
     "wof:parent_id":102191581,
     "wof:placetype":"country",

--- a/data/856/812/41/85681241.geojson
+++ b/data/856/812/41/85681241.geojson
@@ -26,7 +26,7 @@
     "mps:latitude":54.220833,
     "mps:longitude":-4.530069,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":18.0,
     "mz:min_zoom":18.0,
     "name:ace_x_preferred":[
@@ -466,8 +466,10 @@
         "gn:id":6620382,
         "gp:id":23424847,
         "hasc:id":"IM",
+        "iso:code":"IM-IM",
         "qs_pg:id":1314361
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         85632461
     ],
@@ -489,7 +491,7 @@
         "eng",
         "glv"
     ],
-    "wof:lastmodified":1694493128,
+    "wof:lastmodified":1695884287,
     "wof:name":"Isle of Man",
     "wof:parent_id":85632461,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.